### PR TITLE
Fix JWT security issues: hardcoded secret, password leak, filter crash

### DIFF
--- a/src/main/java/com/ejercicio/jwtsecurity/controller/MainController.java
+++ b/src/main/java/com/ejercicio/jwtsecurity/controller/MainController.java
@@ -4,6 +4,7 @@ import com.ejercicio.jwtsecurity.model.User;
 import com.ejercicio.jwtsecurity.service.UserService;
 import com.ejercicio.jwtsecurity.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 public class MainController {
@@ -33,18 +35,16 @@ public class MainController {
 
     @PostMapping("/sing-up")
     public User singUp(@RequestBody User user) {
-        return userService.addUser(user);
+        User created = userService.addUser(user);
+        created.setPassword(null);
+        return created;
     }
 
     @PostMapping("/login")
-    public String login(@RequestBody User user) throws Exception {
+    public String login(@RequestBody User user) {
         User storedUser = userService.findUserByName(user.getName());
-        if (storedUser == null){
-            throw new Exception("User not found");
-        }
-
-        if (!passwordEncoder.matches(user.getPassword(), storedUser.getPassword())){
-            throw new Exception("Invalid password");
+        if (storedUser == null || !passwordEncoder.matches(user.getPassword(), storedUser.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Usuario o contraseña incorrectos");
         }
         return jwtUtil.generateToken(user.getName());
     }

--- a/src/main/java/com/ejercicio/jwtsecurity/filter/JwtFilter.java
+++ b/src/main/java/com/ejercicio/jwtsecurity/filter/JwtFilter.java
@@ -1,11 +1,13 @@
 package com.ejercicio.jwtsecurity.filter;
 
 import com.ejercicio.jwtsecurity.util.JwtUtil;
+import io.jsonwebtoken.JwtException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -34,15 +36,18 @@ public class JwtFilter extends OncePerRequestFilter {
         String username;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             jwtToken = authHeader.substring(7);
-            username = jwtUtil.extractUsername(jwtToken);
-            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-                if(jwtUtil.validateToken(jwtToken, userDetails)) {
-                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                    usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            try {
+                username = jwtUtil.extractUsername(jwtToken);
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                    if (jwtUtil.validateToken(jwtToken, userDetails)) {
+                        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                        usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                    }
                 }
-
+            } catch (JwtException | UsernameNotFoundException | IllegalArgumentException e) {
+                // Token inválido, expirado o de un usuario inexistente: la petición sigue sin autenticar.
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/ejercicio/jwtsecurity/util/JwtUtil.java
+++ b/src/main/java/com/ejercicio/jwtsecurity/util/JwtUtil.java
@@ -3,6 +3,7 @@ package com.ejercicio.jwtsecurity.util;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +15,8 @@ import java.util.function.Function;
 @Service
 public class JwtUtil {
 
-    private String secret = "loquesealoquesea";
+    @Value("${jwt.secret}")
+    private String secret;
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 spring.application.name=jwt-security
 spring.h2.console.enabled:true
+
+# Base64-encoded HS256 signing key. Override via JWT_SECRET env var in real deployments.
+jwt.secret=${JWT_SECRET:7FihNaYlbEN7zk6YiBuIGtSY5ISB8iYsKElZ/QBOkBc=}


### PR DESCRIPTION
## Summary
- El secreto de firma JWT estaba hardcodeado en el código (`JwtUtil`); ahora se externaliza a `application.properties` (sobreescribible con `JWT_SECRET`) y se usa una clave aleatoria de 256 bits.
- `/sing-up` devolvía el `User` completo, incluyendo el hash de la contraseña; ahora se limpia antes de responder.
- `JwtFilter` no capturaba excepciones al parsear un token inválido/expirado, provocando un 500; ahora esos casos simplemente dejan la petición sin autenticar.
- `/login` distinguía "usuario no encontrado" de "contraseña incorrecta" en el mensaje de error, permitiendo enumerar usuarios; ahora responde 401 con un mensaje genérico en ambos casos.

## Test plan
- [x] `./mvnw compile` sin errores
- [x] `./mvnw test` — el contexto de Spring levanta correctamente con el nuevo `jwt.secret`